### PR TITLE
Fix Metamath link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ntg
-Number Theory Game for [Metamath](us.metamath.org)
+Number Theory Game for [Metamath](https://us.metamath.org)
 
 This is a development of Peano Arithemtic based on Robert Solovay's file [peano.mm](https://github.com/metamath/set.mm/blob/develop/peano.mm), 
 which comes included in the [metamath distribution](https://github.com/metamath).


### PR DESCRIPTION
The current link is a local link to a file in the current repository.

Specifically, it goes here: https://github.com/pbrosnan/ntg/blob/main/us.metamath.org

Which is clearly unintended.